### PR TITLE
fix: Memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,10 @@ The request method used for requests to the shadow backend (default `"GET"`).
 ### `disable_host_sanitize` (optional)
 
 Disable host sanitization for prodived `host` list (default `false`).
+
+---
+
+### `timeout` (optional)
+
+The timeout for the request to the shadow backend as a `Go` duration, for
+example `10s`. Defaults to the endpoint timeout.

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/kivra/krakend-shadowproxy
 go 1.19
 
 require (
-	github.com/luraproject/lura/v2 v2.0.5
-	golang.org/x/text v0.4.0
+	github.com/luraproject/lura/v2 v2.2.4
+	golang.org/x/text v0.7.0
 )
 
 require (
@@ -12,4 +12,4 @@ require (
 	github.com/valyala/fastrand v1.1.0 // indirect
 )
 
-replace github.com/luraproject/lura/v2 v2.0.5 => github.com/kivra/lura/v2 v2.0.6-0.20220705080224-3d4d9afe2806
+replace github.com/luraproject/lura/v2 v2.2.4 => github.com/kivra/lura/v2 v2.2.4-0.20230223094107-954b8442a9d9

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-github.com/kivra/lura/v2 v2.0.6-0.20220705080224-3d4d9afe2806 h1:/gVy30uohsIe7nfJHq2ik+BCn+s4dB4pATcQgjv6+SA=
-github.com/kivra/lura/v2 v2.0.6-0.20220705080224-3d4d9afe2806/go.mod h1:r2N4j89Snm1j+Y9CCa9cYR1T2ETRL0E4y9P+DgymqX4=
+github.com/kivra/lura/v2 v2.2.4-0.20230223094107-954b8442a9d9 h1:leO74jYgiPoJCvht+c94UAqIFugpLoVT848dBaWrFnc=
+github.com/kivra/lura/v2 v2.2.4-0.20230223094107-954b8442a9d9/go.mod h1:9I9v5M0Rlg4jlrX3UhgKZ4jbP9gxEvYnJq6VZ9pj/L8=
 github.com/krakendio/flatmap v1.1.1 h1:rGBNVpBY0pMk6cLOwerVzoKY4HELnpu0xvqB231lOCQ=
 github.com/krakendio/flatmap v1.1.1/go.mod h1:KBuVkiH5BcBFRa5A1HdSHDn8a8LzsyRTKZArX0vqTbo=
 github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
 github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
-golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
-golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
+golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=

--- a/proxy_factory.go
+++ b/proxy_factory.go
@@ -17,7 +17,7 @@ func ProxyFactory(pf proxy.Factory) proxy.FactoryFunc {
 		if err != nil {
 			panic(err)
 		}
-		prxCfg, ok := configGetter(cfg.ExtraConfig)
+		prxCfg, ok := configGetter(cfg)
 		if !ok {
 			return next, nil
 		}
@@ -25,7 +25,7 @@ func ProxyFactory(pf proxy.Factory) proxy.FactoryFunc {
 		if err != nil {
 			panic(err)
 		}
-		return proxy.ShadowMiddleware(next, shadowProxy), nil
+		return proxy.ShadowMiddlewareWithTimeout(prxCfg.Timeout, next, shadowProxy), nil
 	}
 }
 
@@ -38,7 +38,7 @@ func shadowConfig(cfg config.EndpointConfig, prxCfg ProxyConfig) *config.Endpoin
 		HostSanitizationDisabled: prxCfg.HostSanitizationDisabled,
 		URLKeys:                  urlKeys,
 		Encoding:                 encoding.NOOP,
-		Timeout:                  cfg.Timeout,
+		Timeout:                  prxCfg.Timeout,
 	}}
 	return &cfg
 }

--- a/shadowproxy.go
+++ b/shadowproxy.go
@@ -3,15 +3,25 @@ package shadowproxy
 import (
 	"bytes"
 	"encoding/json"
+	"time"
 
 	"github.com/luraproject/lura/v2/config"
 )
 
-type ProxyConfig struct {
+type jsonConfig struct {
 	Host                     []string `json:"host"`
 	URLPattern               string   `json:"url_pattern"`
 	Method                   string   `json:"method"`
 	HostSanitizationDisabled bool     `json:"disable_host_sanitize"`
+	Timeout                  string   `json:"timeout"`
+}
+
+type ProxyConfig struct {
+	Host                     []string
+	URLPattern               string
+	Method                   string
+	HostSanitizationDisabled bool
+	Timeout                  time.Duration
 }
 
 const Namespace = "kivra/shadowproxy"
@@ -20,10 +30,11 @@ func addNameSpace(s string) string {
 	return Namespace + ": " + s
 }
 
-func configGetter(e config.ExtraConfig) (*ProxyConfig, bool) {
+func configGetter(e *config.EndpointConfig) (*ProxyConfig, bool) {
+	jsonCfg := new(jsonConfig)
 	cfg := new(ProxyConfig)
 
-	tmp, ok := e[Namespace]
+	tmp, ok := e.ExtraConfig[Namespace]
 	if !ok {
 		return cfg, false
 	}
@@ -32,8 +43,23 @@ func configGetter(e config.ExtraConfig) (*ProxyConfig, bool) {
 	if err := json.NewEncoder(buf).Encode(tmp); err != nil {
 		panic(addNameSpace("Error: failed to parse proxy config: " + err.Error()))
 	}
-	if err := json.NewDecoder(buf).Decode(cfg); err != nil {
+	if err := json.NewDecoder(buf).Decode(jsonCfg); err != nil {
 		panic(addNameSpace("Error: failed to parse proxy config: " + err.Error()))
+	}
+
+	cfg.Host = jsonCfg.Host
+	cfg.HostSanitizationDisabled = jsonCfg.HostSanitizationDisabled
+	cfg.Method = jsonCfg.Method
+	cfg.URLPattern = jsonCfg.URLPattern
+
+	if jsonCfg.Timeout == "" {
+		cfg.Timeout = e.Timeout
+	} else {
+		t, err := time.ParseDuration(jsonCfg.Timeout)
+		if err != nil {
+			panic(addNameSpace("Error: failed to parse proxy timeout config: " + err.Error()))
+		}
+		cfg.Timeout = t
 	}
 
 	if cfg.Method == "" {


### PR DESCRIPTION
## About

Use `ShadowMiddlewareWithTimeout` instead of `ShadowMiddleware` to fix a memory leak (see [here](https://github.com/krakendio/krakend-ce/issues/671)).