### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 on: [push]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
-on: [push]
-
+---
+name: ci
 permissions:
-  contents: read
+  pull-requests: write
 
+on:
+  push:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 name: ci
 permissions:
-  pull-requests: write
+  pull-requests: read
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ permissions:
 
 on:
   push:
+  
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
Potential fix for [https://github.com/kivra/krakend-shadowproxy/security/code-scanning/2](https://github.com/kivra/krakend-shadowproxy/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs linting and testing, it does not require write access. The `permissions` block should be added at the root level of the workflow to apply to all jobs. The minimal permissions required are `contents: read`, which allows the workflow to read repository contents without granting write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
